### PR TITLE
Syntax error while using the specterr gem

### DIFF
--- a/specterr.gemspec
+++ b/specterr.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "specterr/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "specterr
+  spec.name          = "specterr"
   spec.version       = Specterr::VERSION
   spec.authors       = ["Gaurav Singh"]
   spec.email         = ["gaurav.singh@coupa.com"]


### PR DESCRIPTION
[!] There was an error while loading `specterr.gemspec`: syntax error, unexpected tCONSTANT, expecting keyword_end -  spec.authors     

#hacktoberfest

