### PR TITLE
Fix rspec test suite failing on usage of Rails namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,60 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+       - image: circleci/ruby:2.4.1-node-browsers
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+        
+      # Database setup
+#      - run: bundle exec rake db:create
+#      - run: bundle exec rake db:schema:load
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            mkdir /tmp/test-results
+            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
+            
+            bundle exec rspec --format progress \
+                            --out /tmp/test-results/rspec.xml \
+                            --format progress \
+                            $TEST_FILES
+
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results

--- a/lib/specterr.rb
+++ b/lib/specterr.rb
@@ -22,14 +22,16 @@ require "sqlite3"
 # end
 
 module Specterr
-  class RailsInstrumentation < ::Rails::Railtie
-    extend DbInit
+  if defined?(::Rails::Railtie)
+    class RailsInstrumentation < ::Rails::Railtie
+      extend DbInit
 
-    intialize_db
+      intialize_db
 
-    config.after_initialize do
-      ActiveSupport::Notifications.subscribe "process_action.action_controller" do |*args|
-        EventJob::EventTask.perform_async(args.extract_options!)
+      config.after_initialize do
+        ActiveSupport::Notifications.subscribe "process_action.action_controller" do |*args|
+          EventJob::EventTask.perform_async(args.extract_options!)
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require "sucker_punch"
 require "bundler/setup"
 require "specterr"
 


### PR DESCRIPTION
Output on running `bundle exec rspec`
```
Failure/Error:
    class RailsInstrumentation < ::Rails::Railtie
      extend DbInit

      intialize_db

      config.after_initialize do
        ActiveSupport::Notifications.subscribe "process_action.action_controller" do |*args|
          EventJob::EventTask.perform_async(args.extract_options!)
        end
      end

NameError:
  uninitialized constant Rails
```
