### PR TITLE
Create adapters for different databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 
 #Ignore IDE preferences
 /.idea
+*.db

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     specterr (0.1.0)
+      pg
       sqlite3 (~> 1.3, >= 1.3.11)
       sucker_punch (~> 2.0)
 
@@ -10,6 +11,7 @@ GEM
   specs:
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
+    pg (1.1.3)
     rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)

--- a/lib/config/database_config.rb
+++ b/lib/config/database_config.rb
@@ -19,16 +19,16 @@ module DatabaseConfig
   end
 
   def db_config_file_exists?
-    File.exists? db_config_file_path
+    File.exist? db_config_file_path
   end
 
   def db_config_file_path
-    "#{Rails.root}/config/specterr.yml"
+    "./config/specterr.yml"
   end
 
   def default_config
     {
-      adapter: sqlite3,
+      adapter: 'sqlite3',
       pool: ENV.fetch("RAILS_MAX_THREADS") { 5 },
       timeout: 5000,
       database: "db/specterr-#{env}.db"

--- a/lib/config/database_connection.rb
+++ b/lib/config/database_connection.rb
@@ -1,9 +1,23 @@
+require 'config/database_config'
+require 'pg'
+
 module DatabaseConnection
 
+  include DatabaseConfig
   # TODO - get database details from yml
   # Its not a singleton yet
   # Have to create a singleton if not already
   def get_db_connection
-    @db ||= SQLite3::Database.open("spectacles-#{Rails.env}.db")
+    config = read_database_config
+    if config.dig(:adapter) == 'postgresql'
+      config[:user] = config.delete(:username) if config[:username]
+      config[:dbname] = config.delete(:database) if config[:database]
+      config.delete(:adapter)
+      valid_param_keys = PG::Connection.conndefaults_hash.keys + [:requiressl]
+      config.slice!(*valid_param_keys)
+      @db ||= PG::Connection.new(config)
+    else
+      @db ||= SQLite3::Database.open("spectacles-#{Rails.env}.db")
+    end
   end
 end

--- a/lib/event_job/event_job.rb
+++ b/lib/event_job/event_job.rb
@@ -8,18 +8,18 @@ module EventJob
 
     def perform(event)
       db = get_db_connection
-      if data[:exception].present?
-        err_object = data[:exception_object]
+      if event[:exception].present?
+        err_object = event[:exception_object]
 
-        path = data[:path]
-        params = data[:params]
-        method = data[:method]
-        format = data[:format]
-        db_runtime = data[:db_runtime]
-        view_runtime = data[:view_runtime]
-        line_no = data[:line_no]
+        path = event[:path]
+        params = event[:params]
+        method = event[:method]
+        format = event[:format]
+        db_runtime = event[:db_runtime]
+        view_runtime = event[:view_runtime]
+        line_no = event[:line_no]
 
-        header = data[:headers]
+        header = event[:headers]
         req_host = header.env['HTTP_HOST']
         agent = header.env['HTTP_USER_AGENT']
         ip_address = header.env['REMOTE_ADDR']
@@ -33,22 +33,22 @@ module EventJob
           exception, method, path, back_trace, params,
           format, db_runtime, view_runtime, req_host, agent,
           ip_address, line_no, created_at)
-        VALUES (#{event.fetch(:exception,[]).join('-')}, 
-                #{method},
-                #{path},
-                #{back_trace},
-                #{params},
-                #{format},
-                #{db_runtime},
-                #{view_runtime},
-                #{req_host},
-                #{agent},
-                #{ip_address},
-                #{line_no},
-                #{Time.current})
+        VALUES ('#{event.fetch(:exception,[]).join('-')}', 
+                '#{method}',
+                '#{path}',
+                '#{PG::Connection.escape_string(back_trace.compact.join(", "))}',
+                '#{params}',
+                '#{format}',
+                '#{db_runtime}',
+                '#{view_runtime}',
+                '#{req_host}',
+                '#{agent}',
+                '#{ip_address}',
+                '#{line_no}',
+                '#{Time.current}')
         SQL
-
-        db.execute(query)
+        puts "Query: #{query}"
+        db.exec(query)
 
       end
     end

--- a/specterr.gemspec
+++ b/specterr.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'sucker_punch', '~> 2.0'
   spec.add_dependency 'sqlite3', '~> 1.3', '>= 1.3.11'
+  spec.add_dependency 'pg'
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
We have to create adapters for mysql, postresql and sqlite to support different databases through YAML file.
All adapters will accept params based on the database defined in specter.yml and return the database object which can be used for initializing database and creating events.