### PR TITLE
PG / SQLite3 compatibility in error fetching logic that displayed error on specterr web UI.

### DIFF
--- a/lib/specterr/services/errors_list_service.rb
+++ b/lib/specterr/services/errors_list_service.rb
@@ -11,7 +11,7 @@ module Specterr
                     SELECT * from spect_analytics
                  SQL
                else
-                 db.exec <<-SQL
+                 db.execute <<-SQL
                     SELECT * from spect_analytics
                  SQL
                end
@@ -26,7 +26,7 @@ module Specterr
                     where id = '#{id}'
                  SQL
                else
-                 db.exec <<-SQL
+                 db.execute <<-SQL
                     SELECT * from spect_analytics
                     where id = '#{id}'
                  SQL

--- a/lib/specterr/web.rb
+++ b/lib/specterr/web.rb
@@ -67,11 +67,3 @@ module Specterr
 
   end
 end
-
-
-# app = Rack::Builder.new do
-#   use Rack::Deflater        # GZip
-#   run Specterr::Web
-# end
-#
-# Rack::Server.start :app => app

--- a/web/views/index.html.erb
+++ b/web/views/index.html.erb
@@ -1,4 +1,3 @@
-
 <p class="text-danger">.text-danger</p>
 <div class="container">
   <table class="table table-hover">


### PR DESCRIPTION
To reproduce,

- Setup as per https://github.com/dtreelabs/specterr/wiki/Getting-Started
- View web UI to view errors at http://localhost:3000/specterr

Throws an exception if chosen database is non pg database.
