### PR TITLE
Create generator to add mount in routes.rb of rails application

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ gem "specterr", git: "https://github.com/dtreelabs/specterr.git"
 
 ## Development
 
-For using the gem from local folder to a rails project use - 
+For using the gem from local folder to a rails project use -
 ```ruby
 gem 'specterr', path: '<absolute path for developement folder>'
- 
+
 # for example
 # gem 'specterr', path: '/usr/local/workspace/specterr'
 ```
@@ -45,7 +45,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/dtreelabs/specterr. Please refer [Getting Started](https://github.com/dtreelabs/specterr/wiki) wiki page to setup Specterr for development. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/dtreelabs/specterr. Please refer [Getting Started](https://github.com/dtreelabs/specterr/wiki/Getting-Started) wiki page to setup Specterr for development. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 

--- a/lib/config/db_init.rb
+++ b/lib/config/db_init.rb
@@ -4,6 +4,7 @@ module DbInit
   include DatabaseConnection
 
   def intialize_db
+    return unless db_config_file_exists?
     db = get_db_connection
 
     if db.class == PG::Connection

--- a/lib/generators/specterr/USAGE
+++ b/lib/generators/specterr/USAGE
@@ -2,7 +2,7 @@ Description:
     Create specterr.yml in Rail.root/config folder which will be used by this gem to add database details
 
 Example:
-    rails generate specterr Thing
+    rails generate specterr
 
     This will create:
         specterr.yml in config folder

--- a/lib/generators/specterr/specterr_generator.rb
+++ b/lib/generators/specterr/specterr_generator.rb
@@ -4,6 +4,14 @@ class SpecterrGenerator < Rails::Generators::Base
   source_root File.expand_path('../templates', __FILE__)
 
   def create_specterr_file
-    create_file "config/specterr.yml", "adapter: sqlite3,\npool:  5,\ntimeout: 5000,\ndatabase: db/specterr.db"
+    create_file "config/specterr.yml", default_postgresql_config
+  end
+
+  def default_postgresql_config
+    "adapter: postgresql\ndatabase: <database_name>\nusername: <user_name>\npassword: <password>\nhost: <hostname>\nport: <port>"
+  end
+
+  def default_sqlite_config
+    "adapter: sqlite3,\npool:  5,\ntimeout: 5000,\ndatabase: db/specterr.db"
   end
 end


### PR DESCRIPTION
## Description
Currently we have to manually mount the specterr in routes.rb of rails application. Write a generator which can add following lines in routes.rb-
```
require 'specterr/web'
mount Specterr::Web => '/specterr'
```